### PR TITLE
The integration test for the New Launch Instance wizard

### DIFF
--- a/openstack_dashboard/test/integration_tests/pages/admin/system/instancespage.py
+++ b/openstack_dashboard/test/integration_tests/pages/admin/system/instancespage.py
@@ -1,0 +1,18 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from openstack_dashboard.test.integration_tests.pages.project.compute \
+    import instancespage
+
+
+class InstancesPage(instancespage.InstancesPage):
+    pass

--- a/openstack_dashboard/test/integration_tests/regions/forms.py
+++ b/openstack_dashboard/test/integration_tests/regions/forms.py
@@ -111,10 +111,20 @@ class CheckBoxFormFieldRegion(CheckBoxMixin, BaseFormFieldRegion):
     _element_locator_str_suffix = 'input[type=checkbox]'
 
 
+class RadioButtonFormFieldRegionNG(BaseFormFieldRegion):
+
+    _element_locator_str_suffix = '[btn-radio]'
+
+    @property
+    def name(self):
+        return self.element.get_attribute('name') or \
+            self.element.get_attribute('id')
+
+
 class ChooseFileFormFieldRegion(BaseFormFieldRegion):
     """Choose file field."""
 
-    _element_locator_str_suffix = 'div > input[type=file]'
+    _element_locator_str_suffix = 'input[type=file]'
 
     def choose(self, path):
         self.element.send_keys(path)
@@ -137,31 +147,31 @@ class TextInputFormFieldRegion(BaseTextFormFieldRegion):
     """Text input box."""
 
     _element_locator_str_suffix = \
-        'div > input[type=text], div > input[type=None]'
+        'input[type=text], input[type=None]'
 
 
 class PasswordInputFormFieldRegion(BaseTextFormFieldRegion):
     """Password text input box."""
 
-    _element_locator_str_suffix = 'div > input[type=password]'
+    _element_locator_str_suffix = 'input[type=password]'
 
 
 class EmailInputFormFieldRegion(BaseTextFormFieldRegion):
     """Email text input box."""
 
-    _element_locator_str_suffix = 'div > input[type=email]'
+    _element_locator_str_suffix = 'input[type=email]'
 
 
 class TextAreaFormFieldRegion(BaseTextFormFieldRegion):
     """Multi-line text input box."""
 
-    _element_locator_str_suffix = 'div > textarea'
+    _element_locator_str_suffix = 'textarea'
 
 
 class IntegerFormFieldRegion(BaseFormFieldRegion):
     """Integer input box."""
 
-    _element_locator_str_suffix = 'div > input[type=number]'
+    _element_locator_str_suffix = 'input[type=number]'
 
     @property
     def value(self):
@@ -175,7 +185,7 @@ class IntegerFormFieldRegion(BaseFormFieldRegion):
 class SelectFormFieldRegion(BaseFormFieldRegion):
     """Select box field."""
 
-    _element_locator_str_suffix = 'div > select'
+    _element_locator_str_suffix = 'select'
 
     def is_displayed(self):
         return self.element._el.is_displayed()
@@ -193,7 +203,8 @@ class SelectFormFieldRegion(BaseFormFieldRegion):
 
     @property
     def name(self):
-        return self.element._el.get_attribute('name')
+        raw_el = self.element._el
+        return raw_el.get_attribute('name') or raw_el.get_attribute('id')
 
     @property
     def text(self):
@@ -410,7 +421,7 @@ class TabbedFormRegion(FormRegion):
                 self._dynamic_properties[accessor_name] = fields[accessor_expr]
             else:  # it is a class
                 self._dynamic_properties[accessor_name] = accessor_expr(
-                    self.driver, self.conf)
+                    self.driver, self.conf, self.fields_src_elem)
 
     def switch_to(self, tab_index=0):
         self.tabs.switch_to(index=tab_index)
@@ -420,6 +431,21 @@ class TabbedFormRegion(FormRegion):
     def tabs(self):
         return menus.TabbedMenuRegion(self.driver, self.conf,
                                       src_elem=self.src_elem)
+
+
+class TabbedFormRegionNG(TabbedFormRegion):
+    """Forms that are divided with vertical tabs.
+       These forms are implemented in angular-js and
+       have transfer-tables as usual field's element.
+    """
+
+    _submit_locator = (by.By.CSS_SELECTOR, 'button.btn.btn-primary.finish')
+    _header_locator = (by.By.CSS_SELECTOR, '.modal-header > .h4')
+    _fields_locator = (by.By.CSS_SELECTOR, '.step ng-include[ng-form]')
+
+    @property
+    def tabs(self):
+        return menus.TabbedMenuRegionNG(self.driver, self.conf)
 
 
 class DateFormRegion(BaseFormRegion):

--- a/openstack_dashboard/test/integration_tests/regions/menus.py
+++ b/openstack_dashboard/test/integration_tests/regions/menus.py
@@ -240,7 +240,6 @@ class UserDropDownMenuRegion(DropDownMenuRegion):
 
 
 class TabbedMenuRegion(baseregion.BaseRegion):
-
     _tab_locator = (by.By.CSS_SELECTOR, 'a')
     _default_src_locator = (by.By.CSS_SELECTOR, '.selenium-nav-region')
 
@@ -248,8 +247,12 @@ class TabbedMenuRegion(baseregion.BaseRegion):
         self._get_elements(*self._tab_locator)[index].click()
 
 
-class ProjectDropDownRegion(DropDownMenuRegion):
+class TabbedMenuRegionNG(TabbedMenuRegion):
+    _tab_locator = (by.By.CSS_SELECTOR, 'li.nav-item')
+    _default_src_locator = (by.By.CSS_SELECTOR, '.wizard-nav')
 
+
+class ProjectDropDownRegion(DropDownMenuRegion):
     _menu_first_child_locator = (by.By.CSS_SELECTOR, '*')
     _menu_items_locator = (
         by.By.CSS_SELECTOR, 'ul.context-selection li > a')
@@ -262,3 +265,37 @@ class ProjectDropDownRegion(DropDownMenuRegion):
         else:
             raise exceptions.NoSuchElementException(
                 "Not found element with text: %s" % name)
+
+
+class TransferTableMenuRegion(baseregion.BaseRegion):
+    """Class that represents Angular transfer table."""
+    _default_src_locator = (by.By.CSS_SELECTOR, '.transfer-table')
+
+    _allocated_locator = (by.By.CSS_SELECTOR, '.transfer-allocated tbody > tr')
+    _available_locator = (by.By.CSS_SELECTOR, '.transfer-available tbody > tr')
+    _add_remove_sublocator = (by.By.CSS_SELECTOR, 'td.action-col .btn')
+    _comp_cell_sublocator = (by.By.CSS_SELECTOR, 'td')
+
+    def _get_item_name(self, element):
+        cells = element.find_elements(*self._comp_cell_sublocator)
+        return cells and cells[1].text
+
+    @property
+    def available_items(self):
+        return {self._get_item_name(el): el for el in
+                self._get_elements(*self._available_locator)}
+
+    @property
+    def allocated_items(self):
+        return {self._get_item_name(el): el for el in
+                self._get_element(*self._allocated_locator)}
+
+    def allocate_item(self, name):
+        item = self.available_items[name]
+        allocate_btn = item.find_element(*self._add_remove_sublocator)
+        allocate_btn.click()
+
+    def deallocate_item(self, name):
+        item = self.allocated_items[name]
+        deallocate_btn = item.find_element(*self._add_remove_sublocator)
+        deallocate_btn.click()

--- a/openstack_dashboard/test/integration_tests/regions/tables.py
+++ b/openstack_dashboard/test/integration_tests/regions/tables.py
@@ -53,9 +53,11 @@ class TableRegion(baseregion.BaseRegion):
     _rows_locator = (by.By.CSS_SELECTOR, 'tbody > tr')
     _empty_table_locator = (by.By.CSS_SELECTOR, 'tbody > tr.empty')
     _search_field_locator = (by.By.CSS_SELECTOR,
-                             'div.table_search.client > input')
+                             'div.table_search input.form-control')
     _search_button_locator = (by.By.CSS_SELECTOR,
-                              'div.table_search.client > button')
+                              'div.table_search > button')
+    _search_option_locator = (by.By.CSS_SELECTOR,
+                              'div.table_search select.form-control')
     marker_name = 'marker'
     prev_marker_name = 'prev_marker'
 
@@ -102,9 +104,12 @@ class TableRegion(baseregion.BaseRegion):
         self._set_search_field(value)
         self._click_search_btn()
 
+    def set_filter_value(self, value):
+        srch_option = self._get_element(*self._search_option_locator)
+        return self._select_dropdown_by_value(value, srch_option)
+
     def get_row(self, column_name, text, exact_match=True):
         """Get row that contains specified text in specified column.
-
         In case exact_match is set to True, text contained in row must equal
         searched text, otherwise occurrence of searched text in the column
         text will result in row match.
@@ -127,6 +132,7 @@ class TableRegion(baseregion.BaseRegion):
 
     def _set_search_field(self, value):
         srch_field = self._get_element(*self._search_field_locator)
+        srch_field.clear()
         srch_field.send_keys(value)
 
     def _click_search_btn(self):
@@ -184,14 +190,17 @@ class TableRegion(baseregion.BaseRegion):
             lnk = self._get_element(*self._prev_locator)
             lnk.click()
 
-    def assert_definition(self, expected_table_definition):
-        """Checks that actual image table is expected one.
+    def assert_definition(self, expected_table_definition, sorting=False):
+        """Checks that actual table is expected one.
         Items to compare: 'next' and 'prev' links, count of rows and names of
-        images in list
+        elements in list
         :param expected_table_definition: expected values (dictionary)
+        :param sorting: boolean arg specifying whether to sort actual names
         :return:
         """
         names = [row.cells['name'].text for row in self.rows]
+        if sorting:
+            names.sort()
         actual_table = {'Next': self.is_next_link_available(),
                         'Prev': self.is_prev_link_available(),
                         'Count': len(self.rows),

--- a/openstack_dashboard/test/integration_tests/tests/test_instances.py
+++ b/openstack_dashboard/test/integration_tests/tests/test_instances.py
@@ -12,28 +12,208 @@
 from openstack_dashboard.test.integration_tests import decorators, helpers
 from openstack_dashboard.test.integration_tests.regions import messages
 
-INSTANCES_NAME = helpers.gen_random_resource_name('instance',
-                                                  timestamp=False)
 
+class TestAdminInstances(helpers.AdminTestCase):
+    INSTANCE_NAME = helpers.gen_random_resource_name('instance',
+                                                     timestamp=False)
 
-class TestInstances(helpers.AdminTestCase):
-    """This is a basic scenario to test:
-    * Create Instance and Delete Instance
-    """
+    @property
+    def instances_page(self):
+        return self.home_pg.go_to_system_instancespage()
 
-    @decorators.skip_new_design
+    def delete_instance(self):
+        instances_page = self.instances_page
+        instances_page.delete_instance(self.INSTANCE_NAME)
+        self.assertTrue(
+            instances_page.find_message_and_dismiss(messages.SUCCESS))
+        self.assertFalse(
+            instances_page.find_message_and_dismiss(messages.ERROR))
+        self.assertTrue(instances_page.is_instance_deleted(self.INSTANCE_NAME))
+
     def test_create_delete_instance(self):
         instances_page = self.home_pg.go_to_compute_instancespage()
-        instances_page.create_instance(INSTANCES_NAME)
-        self.assertTrue(
-            instances_page.find_message_and_dismiss(messages.SUCCESS))
-        self.assertFalse(
-            instances_page.find_message_and_dismiss(messages.ERROR))
-        self.assertTrue(instances_page.is_instance_active(INSTANCES_NAME))
 
-        instances_page.delete_instance(INSTANCES_NAME)
-        self.assertTrue(
-            instances_page.find_message_and_dismiss(messages.SUCCESS))
+        instances_page.create_instance_ng(self.INSTANCE_NAME)
         self.assertFalse(
             instances_page.find_message_and_dismiss(messages.ERROR))
-        self.assertTrue(instances_page.is_instance_deleted(INSTANCES_NAME))
+        self.assertTrue(instances_page.is_instance_active(self.INSTANCE_NAME))
+
+        self.delete_instance()
+
+    def test_instances_pagination(self):
+        """This test checks instance pagination
+        Steps:
+        1) Login to Horizon Dashboard as regular user
+        2) Navigate to user settings page
+        3) Change 'Items Per Page' value to 1
+        4) Go to Project > Compute > Instances page
+        5) Create 2 instances
+        6) Go to appropriate page (depends on user)
+        7) Check that only 'Next' link is available, only one instance is
+        available (and it has correct name) on the first page
+        8) Click 'Next' and check that on the second page only one instance is
+        available (and it has correct name), there is no 'Next' link on page
+        9) Go to user settings page and restore 'Items Per Page'
+        10) Delete created instances via proper page (depends on user)
+        """
+        items_per_page = 1
+        instance_count = 2
+        instance_list = ["{0}-{1}".format(self.INSTANCE_NAME, item)
+                         for item in range(1, instance_count + 1)]
+        first_page_definition = {'Next': True, 'Prev': False,
+                                 'Count': items_per_page,
+                                 'Names': [instance_list[1]]}
+        second_page_definition = {'Next': False, 'Prev': False,
+                                  'Count': items_per_page,
+                                  'Names': [instance_list[0]]}
+
+        settings_page = self.home_pg.go_to_settings_usersettingspage()
+        settings_page.change_pagesize(items_per_page)
+        self.assertTrue(
+            settings_page.find_message_and_dismiss(messages.SUCCESS))
+
+        instances_page = self.home_pg.go_to_compute_instancespage()
+        instances_page.create_instance_ng(self.INSTANCE_NAME,
+                                          instance_count=instance_count)
+        self.assertTrue(instances_page.is_instance_active(instance_list[1]))
+
+        instances_page = self.instances_page
+        instances_page.instances_table.assert_definition(
+            first_page_definition, sorting=True)
+
+        instances_page.instances_table.turn_next_page()
+        instances_page.instances_table.assert_definition(
+            second_page_definition, sorting=True)
+
+        instances_page = self.instances_page
+        instances_page.instances_table.assert_definition(
+            first_page_definition, sorting=True)
+
+        settings_page = self.home_pg.go_to_settings_usersettingspage()
+        settings_page.change_pagesize()
+        self.assertTrue(
+            settings_page.find_message_and_dismiss(messages.SUCCESS))
+
+        instances_page = self.instances_page
+        for instance_name in instance_list:
+            instances_page.delete_instance(instance_name)
+            self.assertTrue(
+                instances_page.find_message_and_dismiss(messages.SUCCESS))
+            self.assertTrue(instances_page.is_instance_deleted(instance_name))
+
+    def test_instances_pagination_and_filtration(self):
+        """This test checks instance pagination and filtration
+        Steps:
+        1) Login to Horizon Dashboard as regular user
+        2) Go to to user settings page
+        3) Change 'Items Per Page' value to 1
+        4) Go to Project > Compute > Instances page
+        5) Create 2 instances
+        6) Go to appropriate page (depends on user)
+        7) Check filter by Name of the first and the second instance in order
+        to have one instance in the list (and it should have correct name) and
+        no 'Next' link is available
+        8) Check filter by common part of Name of in order to have one instance
+        in the list (and it should have correct name) and 'Next' link is
+        available on the first page and is not available on the second page
+        9) Go to user settings page and restore 'Items Per Page'
+        10) Delete created instances via proper page (depends on user)
+
+        """
+        items_per_page = 1
+        instance_count = 2
+        instance_list = ["{0}-{1}".format(self.INSTANCE_NAME, item)
+                         for item in range(1, instance_count + 1)]
+        first_page_definition = {'Next': True, 'Prev': False,
+                                 'Count': items_per_page,
+                                 'Names': [instance_list[1]]}
+        second_page_definition = {'Next': False, 'Prev': False,
+                                  'Count': items_per_page,
+                                  'Names': [instance_list[0]]}
+        filter_first_page_definition = {'Next': False, 'Prev': False,
+                                        'Count': items_per_page,
+                                        'Names': [instance_list[1]]}
+
+        settings_page = self.home_pg.go_to_settings_usersettingspage()
+        settings_page.change_pagesize(items_per_page)
+        self.assertTrue(
+            settings_page.find_message_and_dismiss(messages.SUCCESS))
+
+        instances_page = self.home_pg.go_to_compute_instancespage()
+        instances_page.create_instance_ng(self.INSTANCE_NAME,
+                                          instance_count=instance_count)
+        self.assertTrue(instances_page.is_instance_active(instance_list[1]))
+
+        instances_page = self.instances_page
+        instances_page.instances_table.set_filter_value('name')
+        instances_page.instances_table.filter(instance_list[1])
+        instances_page.instances_table.assert_definition(
+            filter_first_page_definition, sorting=True)
+
+        instances_page.instances_table.filter(instance_list[0])
+        instances_page.instances_table.assert_definition(
+            second_page_definition, sorting=True)
+
+        instances_page.instances_table.filter(self.INSTANCE_NAME)
+        instances_page.instances_table.assert_definition(
+            first_page_definition, sorting=True)
+        instances_page.instances_table.filter('')
+
+        settings_page = self.home_pg.go_to_settings_usersettingspage()
+        settings_page.change_pagesize()
+        self.assertTrue(
+            settings_page.find_message_and_dismiss(messages.SUCCESS))
+
+        instances_page = self.instances_page
+        for instance_name in instance_list:
+            instances_page.delete_instance(instance_name)
+            self.assertTrue(
+                instances_page.find_message_and_dismiss(messages.SUCCESS))
+            self.assertTrue(instances_page.is_instance_deleted(instance_name))
+
+    def test_filter_instances(self):
+        """This test checks filtering of instances by Instance Name
+        Steps:
+        1) Login to Horizon dashboard as regular user
+        2) Go to Project > Compute > Instances
+        3) Create 2 instances
+        4) Go to appropriate page (depends on user)
+        5) Use filter by Instance Name
+        6) Check that filtered table has one instance only (which name is equal
+        to filter value) and no other instances in the table
+        7) Check that filtered table has both instances (search by common part
+        of instance names)
+        8) Set nonexistent instance name. Check that 0 rows are displayed
+        9) Clear filter and delete instances via proper page (depends on user)
+        """
+        instance_count = 2
+        instance_list = ["{0}-{1}".format(self.INSTANCE_NAME, item)
+                         for item in range(1, instance_count + 1)]
+
+        instances_page = self.home_pg.go_to_compute_instancespage()
+        instances_page.create_instance_ng(self.INSTANCE_NAME,
+                                          instance_count=instance_count)
+        self.assertTrue(instances_page.is_instance_active(instance_list[0]))
+
+        instances_page = self.instances_page
+        instances_page.instances_table.set_filter_value('name')
+
+        instances_page.instances_table.filter(instance_list[0])
+        self.assertTrue(instances_page.is_instance_present(instance_list[0]))
+        for instance in instance_list[1:]:
+            self.assertFalse(instances_page.is_instance_present(instance))
+
+        instances_page.instances_table.filter(self.INSTANCE_NAME)
+        for instance in instance_list:
+            self.assertTrue(instances_page.is_instance_present(instance))
+
+        nonexistent_instance_name = "{0}_test".format(self.INSTANCE_NAME)
+        instances_page.instances_table.filter(nonexistent_instance_name)
+        self.assertEqual(instances_page.instances_table.rows, [])
+        instances_page.instances_table.filter('')
+
+        for instance in instance_list:
+            instances_page.delete_instance(instance)
+            self.assertTrue(
+                instances_page.find_message_and_dismiss(messages.SUCCESS))
+            self.assertTrue(instances_page.is_instance_deleted(instance))


### PR DESCRIPTION
The possibility to create a new instance by means of the Angular
Launch Instance wizard is tested, then it is verified that this
instance is deletable as well. During the launch the same default
flavor and image as in case of legacy wizard are used. It is expected
that 'private' / 'public' network will be available to attach to the
instance being created by regular / admin user, correspondingly.

Co-Authored-By: Sergei Chipiga schipiga@mirantis.com
Co-Authored-By: Timur Sufiev tsufiev@mirantis.com

Implements blueprint: horizon-integration-tests-coverage
Change-Id: I99ee271c5294c842147e29766f6f459becf8686a

Conflicts:
    openstack_dashboard/test/integration_tests/pages/project/compute/instancespage.py
    openstack_dashboard/test/integration_tests/tests/test_instances.py
