### PR TITLE
Wait spinner is absent after submit and cancel.

### DIFF
--- a/horizon_autotests/app/pages/login.py
+++ b/horizon_autotests/app/pages/login.py
@@ -34,7 +34,8 @@ class FormLogin(_ui.Form):
     form_login=FormLogin(By.CSS_SELECTOR, 'form'),
     label_alert_message=ui.UI(By.CSS_SELECTOR, 'div.alert-message'),
     label_error_message=ui.UI(By.CSS_SELECTOR, 'div.error'),
-    modal=_ui.initiated_ui.Modal(By.CLASS_NAME, 'modal-backdrop'))
+    modal=_ui.initiated_ui.Modal(By.CLASS_NAME, 'modal-backdrop'),
+    spinner=_ui.initiated_ui.Spinner(By.CLASS_NAME, 'spinner'))
 class PageLogin(pom.Page):
     """Page to login user."""
 

--- a/horizon_autotests/app/ui/fields.py
+++ b/horizon_autotests/app/ui/fields.py
@@ -23,12 +23,12 @@ from selenium.webdriver.common.by import By
 
 
 class TextField(ui.TextField):
+    """Custom text field."""
 
     @property
     @ui.wait_for_presence
     def help_message(self):
-        """Get field help message"""
+        """Get help message of field."""
         return self.webelement.find_element(
-            By.XPATH,
-            'ancestor::*//*[contains(@class, "help-block")]'
-        ).get_attribute('innerText')
+            By.XPATH, 'ancestor::*//*[contains(@class, "help-block")]'
+        ).get_attribute('innerHTML')

--- a/horizon_autotests/app/ui/form.py
+++ b/horizon_autotests/app/ui/form.py
@@ -34,33 +34,40 @@ class Form(ui.Form):
 
     @pom.timeit
     @ui.wait_for_presence
-    def submit(self, modal_absent=True):
+    def submit(self):
         """Submit form."""
         submit_button = ui.Button(*self.submit_locator)
         submit_button.container = self
         submit_button.click()
-
-        if modal_absent:
-            self._modal.wait_for_absence()
+        self._spinner.wait_for_absence()
 
     @pom.timeit
     @ui.wait_for_presence
-    def cancel(self, modal_absent=True):
+    def cancel(self):
         """Cancel form."""
         cancel_button = ui.Button(*self.cancel_locator)
         cancel_button.container = self
         cancel_button.click()
+        self._modal.wait_for_absence()
 
-        if modal_absent:
-            self._modal.wait_for_absence()
+    @property
+    @pom.cache
+    def _spinner(self):
+        container = self.container
+        while True:
+            spinner = getattr(container, 'spinner', None)
+            if spinner:
+                return spinner
+            else:
+                container = container.container
 
     @property
     @pom.cache
     def _modal(self):
         container = self.container
         while True:
-            ui = getattr(container, 'modal', None)
-            if ui:
-                return ui
+            modal = getattr(container, 'modal', None)
+            if modal:
+                return modal
             else:
                 container = container.container

--- a/horizon_autotests/app/ui/initiated_ui.py
+++ b/horizon_autotests/app/ui/initiated_ui.py
@@ -54,7 +54,7 @@ class Spinner(ui.UI):
 
 
 class Modal(ui.Block):
-    """Spinner to wait loading."""
+    """Modal background."""
 
     timeout = ACTION_TIMEOUT
 

--- a/horizon_autotests/steps/volumes.py
+++ b/horizon_autotests/steps/volumes.py
@@ -384,7 +384,7 @@ class VolumesSteps(BaseSteps):
 
     @pom.timeit('Step')
     def create_snapshot(self, volume_name, snapshot_name, description=None,
-                        check=True, modal_absent=True):
+                        check=True):
         """Step to create volume snapshot."""
         tab_volumes = self.tab_volumes()
 
@@ -397,7 +397,7 @@ class VolumesSteps(BaseSteps):
             form.field_name.value = snapshot_name
             if description is not None:
                 self.field_description.value = description
-            form.submit(modal_absent=modal_absent)
+            form.submit()
 
         if check:
             self.close_notification('info')
@@ -481,7 +481,7 @@ class VolumesSteps(BaseSteps):
 
     @pom.timeit('Step')
     def create_backup(self, volume_name, backup_name, description=None,
-                      container=None, check=True, modal_absent=True):
+                      container=None, check=True):
         """Step to create volume backup."""
         tab_volumes = self.tab_volumes()
 
@@ -499,7 +499,7 @@ class VolumesSteps(BaseSteps):
             if container is not None:
                 self.field_container.value = container
 
-            form.submit(modal_absent=modal_absent)
+            form.submit()
 
         if check:
             self.close_notification('success')

--- a/horizon_autotests/tests/test_volume_backups.py
+++ b/horizon_autotests/tests/test_volume_backups.py
@@ -24,12 +24,12 @@ import pytest
 from .fixtures._utils import generate_ids
 
 
+@pytest.mark.reject_if('ceph' not in os.environ.get('JOB_NAME', 'ceph'),
+                       reason="Swift backups are not supported")
 @pytest.mark.usefixtures('any_one')
 class TestAnyOne(object):
     """Tests for any user."""
 
-    @pytest.mark.reject_if('ceph' not in os.environ.get('JOB_NAME', 'ceph'),
-                           reason="Swift backups are not supported")
     def test_volume_backups_pagination(self, create_backups, update_settings,
                                        volumes_steps):
         """Verify that volume backups pagination works right and back."""
@@ -72,14 +72,10 @@ class TestAnyOne(object):
         assert tab_backups.table_backups.link_next.is_present
         assert not tab_backups.table_backups.link_prev.is_present
 
-    @pytest.mark.reject_if('ceph' not in os.environ.get('JOB_NAME', 'ceph'),
-                           reason="Swift backups are not supported")
-    def test_create_backup_without_name(self, volume, volumes_steps):
-        """Create volume backup without name"""
-        volumes_steps.create_backup(volume.name, '', check=False,
-                                    modal_absent=False)
+    def test_cannot_create_backup_without_name(self, volume, volumes_steps):
+        """Verify that volume backup without name cannot be created."""
+        volumes_steps.create_backup(volume.name, backup_name='', check=False)
 
-        tab_volumes = volumes_steps.app.page_volumes.tab_volumes
-        with tab_volumes.form_create_backup as form:
-            assert form.field_name.help_message == u'This field is required.'
-            form.cancel()
+        form = volumes_steps.app.page_volumes.tab_volumes.form_create_backup
+        assert form.field_name.help_message == u'This field is required.'
+        form.cancel()

--- a/horizon_autotests/tests/test_volume_snapshots.py
+++ b/horizon_autotests/tests/test_volume_snapshots.py
@@ -75,16 +75,15 @@ class TestAnyOne(object):
         assert not tab_snapshots.table_snapshots.link_prev.is_present
 
     def test_create_volume_from_snapshot(self, snapshot, volumes_steps):
-        """Verify that user cat create volume from snapshot."""
+        """Verify that user can create volume from snapshot."""
         volumes_steps.create_volume_from_snapshot(snapshot.name)
         volumes_steps.delete_volume(snapshot.name)
 
-    def test_create_snapshot_without_name(self, volume, volumes_steps):
-        """Create volume backup without name"""
-        volumes_steps.create_snapshot(volume.name, '', check=False,
-                                      modal_absent=False)
+    def test_cannot_create_snapshot_without_name(self, volume, volumes_steps):
+        """Verify that volume snapshot without name cannot be created."""
+        volumes_steps.create_snapshot(volume.name, snapshot_name='',
+                                      check=False)
 
-        tab_volumes = volumes_steps.app.page_volumes.tab_volumes
-        with tab_volumes.form_create_snapshot as form:
-            assert form.field_name.help_message == u'This field is required.'
-            form.cancel()
+        form = volumes_steps.app.page_volumes.tab_volumes.form_create_snapshot
+        assert form.field_name.help_message == u'This field is required.'
+        form.cancel()

--- a/requirements
+++ b/requirements
@@ -7,4 +7,4 @@ attrdict
 requests
 waiting
 xvfbwrapper
--egit+https://github.com/sergeychipiga/pom.git@master#egg=pom
+python-pom


### PR DESCRIPTION
We shouldn't wait that modal form is absent after submit or cancel,
because can be (and there are) cases when modal form is still present
after submit.
